### PR TITLE
throw runtime error instead of string from logger

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(cpp-utils VERSION 1.0
+DESCRIPTION "Ross C. Brodie's C++ utilities"
+LANGUAGES CXX)
+
+add_library(file_utils STATIC src/file_utils.cpp)
+target_include_directories(file_utils PUBLIC src)
+set_property(TARGET file_utils PROPERTY CXX_STANDARD 11)
+set_property(TARGET file_utils PROPERTY CXX_STANDARD_REQUIRED ON)
+
+add_library(general_utils STATIC src/general_utils.cpp)
+target_include_directories(general_utils PUBLIC src)
+set_property(TARGET general_utils PROPERTY CXX_STANDARD 11)
+set_property(TARGET general_utils PROPERTY CXX_STANDARD_REQUIRED ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,15 +1,17 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.12)
 
 project(cpp-utils VERSION 1.0
 DESCRIPTION "Ross C. Brodie's C++ utilities"
 LANGUAGES CXX)
 
-add_library(file_utils STATIC src/file_utils.cpp)
+add_library(file_utils OBJECT src/file_utils.cpp src/file_utils.h)
 target_include_directories(file_utils PUBLIC src)
-set_property(TARGET file_utils PROPERTY CXX_STANDARD 11)
-set_property(TARGET file_utils PROPERTY CXX_STANDARD_REQUIRED ON)
 
-add_library(general_utils STATIC src/general_utils.cpp)
+add_library(general_utils OBJECT src/general_utils.cpp src/general_utils.h)
 target_include_directories(general_utils PUBLIC src)
-set_property(TARGET general_utils PROPERTY CXX_STANDARD 11)
-set_property(TARGET general_utils PROPERTY CXX_STANDARD_REQUIRED ON)
+
+set_target_properties(
+  file_utils general_utils
+  PROPERTIES CXX_STANDARD 11
+  CXX_STANDARD_REQUIRED ON
+)


### PR DESCRIPTION
Hi Ross,

I've changed the behaviour of your logger class so it throws an object of class `std::runtime_error` instead of a bare string when something goes wrong. This is so I can catch the exception in the main function of garjmcmc and exit cleanly instead of the program getting terminated and a bunch of core dump files getting written if I do something like type the wrong file name for the .con file.

Thanks
Richard